### PR TITLE
Renamed task type

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -327,6 +327,9 @@ definitions:
         $ref: '#/definitions/Hardware'
       location:
         $ref: '#/definitions/Location'
+      price:
+        type: number
+        format: double
 
   # Platform related definitions:
     

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -258,7 +258,7 @@ definitions:
 
   GeoLocation:
     description:
-      Represents a geographical location
+      Represents a geographical locationgit
     type: object
     properties:
       city:
@@ -514,7 +514,7 @@ definitions:
     required:
       - name
       - executionEnvironment
-      - type
+      - taskType
     properties:
       name:
         description: "Human-readable name. Uniquely identifies a task."
@@ -534,7 +534,7 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Requirement'
-      type:
+      taskType:
         $ref: '#/definitions/TaskType'
         example: |
           {"name":"TaskTest","ports":[{"type":"PortProvided","name":"PortProvidedTest","port":12345}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -258,7 +258,7 @@ definitions:
 
   GeoLocation:
     description:
-      Represents a geographical locationgit
+      Represents a geographical location
     type: object
     properties:
       city:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -270,11 +270,11 @@ definitions:
       latitude:
         description: "Latitude of the location in decimal degrees"
         type: number
-        format: float
+        format: double
       longitude:
         description: "Longitude of the location in decimal degrees"
         type: number
-        format: float
+        format: double
 
   Location:
     description: |


### PR DESCRIPTION
changed 'type' in Task to 'taskType' because of typeconventions
caused this Warning:
>> Other properties are defined at the same level as $ref at "#/definitions/Task/properties/type". They are IGNORED according to the JsonSchema spec <<
