### PR TITLE
Monitor parameter change

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2293,6 +2293,13 @@ paths:
         Retrieves the monitor with the given metric name
       parameters:
         - $ref: '#/parameters/metric'
+        - name: target
+          in: body
+          description: |
+            Target of the Monitor
+          required: true
+          schema:
+            $ref: '#/definitions/MonitoringTarget'
       responses:
         200:
           description: "OK"
@@ -2309,6 +2316,13 @@ paths:
         Deletes the monitor identified by the given metric name.
       parameters:
         - $ref: '#/parameters/metric'
+        - name: target
+          in: body
+          description: |
+            Target of the Monitor
+          required: true
+          schema:
+            $ref: '#/definitions/MonitoringTarget'
       responses:
         200:
           description: "OK"


### PR DESCRIPTION
add MonitoringTarget as Parameter in body:
- GET monitor/{metric}
- DEL monitor/{metric}

belongs to the metric change in monitoring, that a monitormetric should be useable on multiple Processes or Nodes
so the internal monitormetric is extended by targettype and targetID